### PR TITLE
added an optional threshold in early stopping

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -146,7 +146,7 @@ def reset_learning_rate(learning_rates):
     return callback
 
 
-def early_stop(stopping_rounds, maximize=False, verbose=True):
+def early_stop(stopping_rounds, threshold=0, maximize=False, verbose=True):
     """Create a callback that activates early stoppping.
 
     Validation error needs to decrease at least
@@ -230,8 +230,8 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
         best_score = state['best_score']
         best_iteration = state['best_iteration']
         maximize_score = state['maximize_score']
-        if (maximize_score and score > best_score) or \
-                (not maximize_score and score < best_score):
+        if (maximize_score and score > (best_score + threshold)) or \
+                (not maximize_score and score < (best_score + threshold)):
             msg = '[%d]\t%s' % (
                 env.iteration,
                 '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -218,7 +218,7 @@ class XGBModel(XGBModelBase):
         return xgb_params
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None,early_stopping_threshold=None, verbose=True):
         # pylint: disable=missing-docstring,invalid-name,attribute-defined-outside-init
         """
         Fit the gradient boosting model
@@ -252,6 +252,11 @@ class XGBModel(XGBModelBase):
             and bst.best_ntree_limit.
             (Use bst.best_ntree_limit to get the correct value if num_parallel_tree
             and/or num_class appears in the parameters)
+        early_stopping_threshold : float
+            In case of early stopping, gives the least value by which the score 
+            has to improve in order to keep learning. If the model doesn't improve
+            more than this threshold, the learning will stop after early_stopping_rounds
+            iterations.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
@@ -287,6 +292,7 @@ class XGBModel(XGBModelBase):
         self._Booster = train(params, trainDmatrix,
                               self.n_estimators, evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
+                              early_stopping_threshold=early_stopping_threshold,
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose)
 
@@ -406,7 +412,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                                             random_state, seed, missing, **kwargs)
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None, early_stopping_threshold=None, verbose=True):
         # pylint: disable = attribute-defined-outside-init,arguments-differ
         """
         Fit gradient boosting classifier
@@ -440,6 +446,11 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             and bst.best_ntree_limit.
             (Use bst.best_ntree_limit to get the correct value if num_parallel_tree
             and/or num_class appears in the parameters)
+        early_stopping_threshold : float, optional
+            In case of early stopping, gives the least value by which the score 
+            has to improve in order to keep learning. If the model doesn't improve
+            more than this threshold, the learning will stop after early_stopping_rounds
+            iterations.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
@@ -496,6 +507,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         self._Booster = train(xgb_options, train_dmatrix, self.n_estimators,
                               evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
+                              early_stopping_threshold=early_stoping_threshold,
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose)
 


### PR DESCRIPTION
In the early stopping version of the train, added an optional threshold, so that if the scores doesn't improve "more than the threshold" the model will stop learning, even if it has slightly improved.